### PR TITLE
Show whitelist files in Rubocop violations report

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -51,12 +51,12 @@ module Danger
 
       message = "### Rubocop violations\n\n"
       table = Terminal::Table.new(
-        headings: %w(Whitelist File Line Reason),
+        headings: %w(Required File Line Reason),
         style: { border_i: '|' },
         rows: offending_files.flat_map do |file|
           file['offenses'].map do |offense|
             [
-              in_whitelist(file['path'], whitelist),
+              required?(file['path'], whitelist),
               file['path'],
               offense['location']['line'],
               offense['message']
@@ -67,7 +67,7 @@ module Danger
       message + table.split("\n")[1..-2].join("\n")
     end
 
-    def in_whitelist(file, whitelist)
+    def required?(file, whitelist)
       whitelist.include?(file) ? "\u{2757}" : ""
     end
 

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -24,7 +24,7 @@ module Danger
     #          from the diff will be used.
     # @return  [void]
     #
-    def lint(files = nil, whitelist)
+    def lint(files = nil, whitelist = [])
       files_to_lint = fetch_files_to_lint(files)
 
       return if offending_files.empty?
@@ -68,7 +68,7 @@ module Danger
     end
 
     def required?(file, whitelist)
-      whitelist.include?(file) ? "\u{2757}" : ""
+      whitelist.include?(file) ? 'x' : ''
     end
 
     def fetch_files_to_lint(files = nil)

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -24,12 +24,12 @@ module Danger
     #          from the diff will be used.
     # @return  [void]
     #
-    def lint(files = nil)
+    def lint(files = nil, whitelist)
       files_to_lint = fetch_files_to_lint(files)
 
       return if offending_files.empty?
 
-      markdown offenses_message(offending_files)
+      markdown offenses_message(offending_files, whitelist)
     end
 
     def offending_files(files = nil)
@@ -46,22 +46,31 @@ module Danger
         .select { |f| f['offenses'].any? }
     end
 
-    def offenses_message(offending_files)
+    def offenses_message(offending_files, whitelist)
       require 'terminal-table'
 
       message = "### Rubocop violations\n\n"
       table = Terminal::Table.new(
-        headings: %w(File Line Reason),
+        headings: %w(Whitelist File Line Reason),
         style: { border_i: '|' },
         rows: offending_files.flat_map do |file|
           file['offenses'].map do |offense|
-            [file['path'], offense['location']['line'], offense['message']]
+            [
+              in_whitelist(file['path'], whitelist),
+              file['path'],
+              offense['location']['line'],
+              offense['message']
+            ]
           end
         end
       ).to_s
       message + table.split("\n")[1..-2].join("\n")
     end
-    
+
+    def in_whitelist(file, whitelist)
+      whitelist.include?(file) ? ":exclamation:" : ""
+    end
+
     def fetch_files_to_lint(files = nil)
       @files_to_lint ||= (files ? Dir.glob(files) : (git.modified_files + git.added_files))
     end

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -68,7 +68,7 @@ module Danger
     end
 
     def in_whitelist(file, whitelist)
-      whitelist.include?(file) ? ":exclamation:" : ""
+      whitelist.include?(file) ? "\u{2757}" : ""
     end
 
     def fetch_files_to_lint(files = nil)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module DangerRubocop
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -90,9 +90,9 @@ module Danger
 
           formatted_table = <<-EOS
 ### Rubocop violations\n
-| File                       | Line | Reason         |
-|----------------------------|------|----------------|
-| spec/fixtures/ruby_file.rb | 13   | Don't do that! |
+| Required | File                       | Line | Reason         |
+|----------|----------------------------|------|----------------|
+|          | spec/fixtures/ruby_file.rb | 13   | Don't do that! |
 EOS
           expect(@rubocop.status_report[:markdowns].first.message).to eq(formatted_table.chomp)
         end


### PR DESCRIPTION
# Trello card (URL):

None

# Summary

Add a column to show which Rubocop violated file is required to be fixed in order to unblock merging.
See https://github.com/Thinkei/employment-hero/pull/7758/files/5c46384f8a9bf7c47e2651993999f3fc5ec7662e

# Changes proposed in this pull request:
- Edit lib/danger_plugin.rb to change Rubocop violations report

# Checklist