### PR TITLE
Chore/danger ignore cops

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -44,7 +44,7 @@ module Danger
     def rubocop(files_to_lint, cops_to_ignore = [])
       rubocop_output = `#{'bundle exec ' if need_bundler?}rubocop -f json #{files_to_lint.join(' ')}`
 
-      JSON.parse(rubocop_output)['files'].select { |f| f['offenses'].any? }.map do |file|
+      JSON.parse(rubocop_output)['files'].select { |file| file['offenses'].any? }.map do |file|
         file['offenses'].reject! { |offense| cops_to_ignore.include?(offense['cop_name']) }
         file
       end

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -40,7 +40,12 @@ module Danger
     private
 
     def rubocop(files_to_lint)
-      rubocop_output = `#{'bundle exec ' if need_bundler?}rubocop -f json #{files_to_lint.join(' ')}`
+      rubocop_output =
+        if ENV['CIRCLE_BRANCH'] =~ /chore\/fix-rubocop/
+          `#{'bundle exec ' if need_bundler?}rubocop -f json --config .rubocop-except.yml #{files_to_lint.join(' ')}`
+        else
+          `#{'bundle exec ' if need_bundler?}rubocop -f json #{files_to_lint.join(' ')}`
+        end
 
       JSON.parse(rubocop_output)['files']
         .select { |f| f['offenses'].any? }

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 module Danger
   # Run Ruby files through Rubocop.
   # Results are passed out as a table in markdown.

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -44,10 +44,12 @@ module Danger
     def rubocop(files_to_lint, cops_to_ignore = [])
       rubocop_output = `#{'bundle exec ' if need_bundler?}rubocop -f json #{files_to_lint.join(' ')}`
 
-      JSON.parse(rubocop_output)['files'].select { |file| file['offenses'].any? }.map do |file|
-        file['offenses'].reject! { |offense| cops_to_ignore.include?(offense['cop_name']) }
-        file
-      end
+      JSON.parse(rubocop_output)['files'].map do |file|
+        file['offenses'].reject! do |offense|
+          cops_to_ignore.include?(offense['cop_name'])
+        end
+        file unless file['offenses'].empty?
+      end.compact
     end
 
     def offenses_message(offending_files, whitelist)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module DangerRubocop
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end


### PR DESCRIPTION
Summary
=======

Ignore cops listed in `Dangerfile` when linting for `chore/fix-rubocop` pull requests.