### PR TITLE
Ignore custom cops for old files

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module DangerRubocop
-  VERSION = '0.4.2'.freeze
+  VERSION = '0.4.3'.freeze
 end


### PR DESCRIPTION
## Summary
For now, danger-rubocop will ignore offenses belong to custom cops for old files until our migration and refactoring are finished.