### PR TITLE
Ignore custom cops in old files

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -23,7 +23,7 @@ module Danger
 
       JSON.parse(rubocop_output)['files'].map do |file|
         file['offenses'].reject! do |offense|
-          cops_to_ignore.include?(offense['cop_name'])
+          cops_to_ignore.include?(offense['cop_name']) && git.modified_files.include?(file['path'])
         end
         file unless file['offenses'].empty?
       end.compact

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module DangerRubocop
-  VERSION = '0.4.2'.freeze
+  VERSION = '0.4.3'.freeze
 end


### PR DESCRIPTION
## Summary

In `.Dangerfile` (from the main app) we will provide a list of custom cops so that `danger-rubocop` can ignore those cops when it checks every pull requests: if an offense belongs to custom cops and the current file is an old file, it won't add that offense to the report table.