### PR TITLE
Clean up danger plugin and bump version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-rubocop (0.4.2)
+    danger-rubocop (0.5)
       danger
       rubocop
 
@@ -77,7 +77,7 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
     parallel (1.12.1)
-    parser (2.5.0.5)
+    parser (2.5.1.0)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     prettybacon (0.0.2)
@@ -121,7 +121,7 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.19.1)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.3.2)
     yard (0.9.5)
 
 PLATFORMS

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -1,32 +1,25 @@
 module Danger
   class DangerRubocop < Plugin
-    def lint(files = nil, whitelist = [], cops_to_ignore = [])
-      @whitelist = whitelist
-      rubocop_offending_files = offending_files(files, cops_to_ignore)
+    def lint(files = nil)
+      rubocop_offending_files = offending_files(files)
       return unless rubocop_offending_files.any?
-      markdown offenses_message(rubocop_offending_files)
-    end
-
-    def offending_files(files = nil, cops_to_ignore = [])
-      files_to_lint = fetch_files_to_lint(files)
-      rubocop(files_to_lint, cops_to_ignore)
+      [markdown(offenses_message(rubocop_offending_files)), rubocop_offending_files]
     end
 
     private
+
+    def offending_files(files = nil)
+      files_to_lint = fetch_files_to_lint(files)
+      rubocop(files_to_lint)
+    end
 
     def fetch_files_to_lint(files = nil)
       @files_to_lint ||= (files ? Dir.glob(files) : (git.modified_files + git.added_files))
     end
 
-    def rubocop(files_to_lint, cops_to_ignore = [])
+    def rubocop(files_to_lint)
       rubocop_output = `#{'bundle exec ' if need_bundler?}rubocop -f json #{files_to_lint.join(' ')}`
-
-      JSON.parse(rubocop_output)['files'].map do |file|
-        file['offenses'].reject! do |offense|
-          cops_to_ignore.include?(offense['cop_name'])
-        end
-        file unless file['offenses'].empty?
-      end.compact
+      JSON.parse(rubocop_output)['files'].select { |f| f['offenses'].any? }
     end
 
     def offenses_message(offending_files)
@@ -34,12 +27,11 @@ module Danger
 
       message = "### Rubocop violations\n\n"
       table = Terminal::Table.new(
-        headings: %w(Required File Line Reason),
+        headings: %w(File Line Reason),
         style: { border_i: '|' },
         rows: offending_files.flat_map do |file|
           file['offenses'].map do |offense|
             [
-              required?(file['path']) ? ':x:' : '',
               file['path'],
               offense['location']['line'],
               offense['message']
@@ -48,10 +40,6 @@ module Danger
         end
       ).to_s
       message + table.split("\n")[1..-2].join("\n")
-    end
-
-    def required?(file_path)
-      (@whitelist + git.added_files).include?(file_path)
     end
 
     def need_bundler?

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -2,8 +2,9 @@ module Danger
   class DangerRubocop < Plugin
     def lint(files = nil)
       rubocop_offending_files = offending_files(files)
-      return unless rubocop_offending_files.any?
-      [markdown(offenses_message(rubocop_offending_files)), rubocop_offending_files]
+      return [] unless rubocop_offending_files.any?
+      markdown offenses_message(rubocop_offending_files)
+      rubocop_offending_files
     end
 
     private

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module DangerRubocop
-  VERSION = '0.4.2'.freeze
+  VERSION = '0.5'.freeze
 end

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -90,9 +90,9 @@ module Danger
 
           formatted_table = <<-EOS
 ### Rubocop violations\n
-| Required | File                       | Line | Reason         |
-|----------|----------------------------|------|----------------|
-|          | spec/fixtures/ruby_file.rb | 13   | Don't do that! |
+| File                       | Line | Reason         |
+|----------------------------|------|----------------|
+| spec/fixtures/ruby_file.rb | 13   | Don't do that! |
 EOS
           expect(@rubocop.status_report[:markdowns].first.message).to eq(formatted_table.chomp)
         end


### PR DESCRIPTION
Remove the logic checks for `cops_to_ignore` and `whitelist` etc, now Danger will just check Rubocop for whatever file is being passed to it from `Dangerfile`.